### PR TITLE
New env info

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - Support, Maintenance, & Installation Policies: policies/support.md
   - How To:  
     - About: howto/about.md 
+    - CCR New Environment: howto/newenv.md  
     - Conda Environments: howto/conda.md  
     - OnDemand Customization: howto/ondemand.md  
     - Perl Module Install: howto/perl.md

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -9,6 +9,9 @@ If you are unfamiliar with CCR and what services and resources we provide, pleas
 
 This 20 minute presentation given by the CCR Director in 2020 provides a succinct overview.  We will not cover that information here as this site is dedicated to documentation for using our resources  
 ![type:video](https://youtube.com/embed/ryBqdeqTO4o)  
+<br>
+
+==As of August 2023, new users have access to CCR's new environment.  See [here](howto/newenv.md) for more information==  
 
 ## What do you want to do?  
 

--- a/pages/howto/newenv.md
+++ b/pages/howto/newenv.md
@@ -1,0 +1,79 @@
+# CCR's New Environment Explained  
+
+CCR staff have been working for over a year to provide users with an updated environment that includes a new software infrastructure, new compute nodes, and a new operating system.  Additionally, a new core network switch and updated networking protocols have been put into place.  This combination of projects is what we're referring to as CCR's New Environment.  Each of these separately has been a monumental task and we've tried to orchestrate these updates while also keeping the existing infrastructure in place.  Now it's time for everyone to make the transition as the old infrastructure will be decommissioned this fall.  This transistion will involve changes for existing users.  We have tried to keep these changes as easy to navigate as possible, but change can be hard and we're here to help!
+
+This page is intended to provide details to the changes users can expect and break down the experience each user might expect.  Whether you're a long time CCR user or brand new to our center, we hope to smooth out the process of onboarding to the new environment.  Please note this is just an overview document and users should refer to the wealth of information in the rest of our documentation website for all the details of using CCR's resources.  
+
+
+
+
+## New Users 
+
+Users new to CCR after August 8, 2023 will automatically be put into the new environment.  This means you don't need to do anything other than follow the directions [below](#the-new-resources) to access the new compute nodes and new OnDemand service.  If you are a member of a research group that owns their own nodes, you may not want to be in the new environment yet.  You may want to go back to the old environment so you can use your group's nodes until they are transitioned to the new environment.  [See here](#using-the-old-software) for guidance. 
+
+
+## Existing Users - How to Transition 
+
+- Create a file in your home directory named .ccr_new_modules.  Log out & back in again.
+- Ensure that nothing has been added to the `.bashrc` file in your home directory.  Comment out or remove anything not provided by CCR.  This is what your `.bashrc` file should look like:  
+```
+```
+- Follow the directions [below](#the-new-resources) to access the new resources    
+- If you have existing software modules you or your group have built, they will likely need to be re-built for this environment.  See [here](#existing-modules) for more information    
+
+
+## Using the old software  
+If you'd like to remain in the old environment until your group's nodes are transitioned into the new environment, remove the `~/.ccr_new_modules` file and log out and back into `vortex.ccr.buffalo.edu`  You should NOT use `vortex-future` or `ondemand-future` as both these services are only in the new environment.  You should also not use the `ubhpc-future` reservation to submit jobs as the nodes in that reservation are in the new environment and won't work with old modules.  
+
+**What if I want to use my groups nodes AND the new environment?**  
+WE DON'T RECOMMEND THIS!  However, if you want to try, this will involve some manipulation on your part and your mileage may vary.  You could use `vortex-future.ccr.buffalo.edu` or https://ondemand-future.ccr.buffalo.edu to submit jobs to the nodes in the new environment.  Make sure you do not have the `.ccr_new_modules` file in your home directory.  When these jobs run they'll be using the new environment and any software modules you're loading will be from the new software stack.  If you wanted to run on the old UB-HPC cluster nodes or nodes in the faculty cluster that have not been transitioned yet, submit jobs from `vortex.ccr.buffalo.edu` or using https://ondemand.ccr.buffalo.edu, not ondemand-future.  **Keep in mind** many software packages store libraries, cache files, and temporary files in your home directory so trying to use these two environments at the same time may not work.  This will all depend on what software you're using and will be a trial and error process on your part.  Good luck!
+
+
+## The New Resources  
+
+!!! Warning "REMINDER!!!"  
+    Do NOT add anything to the `.bashrc` file in your home directory!  Loading modules, enabling conda environments, and other environment-related tasks will almost certainly break your environment on the CCR systems.  It will break CCR's quota tool, cause OnDemand desktops & apps to fail to start, and cause problems with batch scripts on compute nodes.  
+
+**New Login Server**
+
+You may use the new login server `vortex-future.ccr.buffalo.edu` during the transition.  Eventually all login servers will be setup like this one and you'll be able to access them in the pool using `vortex.ccr.buffalo.edu`  However, for now, the vortex pool has vortex1 and vortex2 that continue to have access to the old software modules.  
+
+
+**New OnDemand**  
+
+To access the new compute nodes and new software via OnDemand, we have installed [OnDemand 3.0](https://ondemand-future.ccr.buffalo.edu).  There are many new features to take advantage of, as well as changes to how we've laid out the apps.  Please [see here](../howto/ondemand.md) for more details.  You will ONLY have access to compute nodes that have been moved to the new environment and ONLY have access to the new software modules.  Faculty cluster nodes will not be available in OnDemand 3.0 until they've been migrated into the new environment.   
+
+The new server URL is:  [https://ondemand-future.ccr.buffalo.edu](https://ondemand-future.ccr.buffalo.edu)
+
+
+**Newest Compute Nodes**
+
+The newest compute nodes available at CCR in the UB-HPC cluster have been put into a reservation for users to access them and the new environment.  You will need to specify the following in your batch scripts:  
+
+```
+#SBATCH --cluster=ub-hpc
+#SBATCH --partition=general-compute
+#SBATCH --qos=general-compute
+#SBATCH --reservation=ubhpc-future
+#SBATCH --export=NONE
+```
+
+**Using `srun`?**  If you use `srun` in your job script you need to change the `--export=NONE` option to `--export=NIL` otherwise your environment will not propogate properly to the compute node.  
+
+**using `salloc`?** If you use `salloc` for interactive jobs, you must specify the reservation in your salloc command and run an additional command after being allocated a node:  
+
+```
+salloc --reservation=ubhpc-future --qos=general-compute --partition=general-compute  --job-name "MyJob" --nodes=1 --ntasks=1 --mem=8G --time=00:30:00  
+
+srun --pty /bin/bash --login
+```
+
+## Existing Modules  
+
+Any modules previously created in the old system will need to be reinstalled into the new modules.  We know, this isn't what you wanted to hear.  We feel your pain.  We're currently trying to reconstruct 20+ years of software installations ourselves.  The reason behind this isn't so much a new version of modules but it's more about the operating system, compilers, and linking used to install your old software.  It is unlikely that this will work in the new operating system.  As part of the software infrastructure, CCR provides a compatiblity layer.  Installing software using this will allow software to work on any Linux-based operating system, no longer tying us (or you) to a specific flavor of Linux.  This is especially coming in handy with all the turmoil over RedHat derivatives we've seen lately.  This is future-proofing us and will allow for the testing of cutting edge operating systems in the future, which has been asked of us by researchers over the years.  If your software did not require building (using compilers) or linking to the system libraries (for example: python scripts), it MAY be POSSIBLE to convert them over to the new module directory structure so they are available to you.  At that point, you can test to see if the software works on compute nodes in the new environment.  This is not something CCR can provide support for; however, if you'd like to try it, you'd need your module(s) to be in the directory structure [defined here](../software/building.md#building-modules-for-your-group) (see specifically the tip in green).  
+
+## Software Installation Requests  
+
+CCR is accepting requests for software installations and encourages users to "like" any requests they see for software they want to use in [this list](https://github.com/ubccr/software-layer/issues).  This helps us to rank the requests and prioritize the order they are installed.  [Follow these instructions](../software/building.md#software-build-requests) to request a software build.  Currently, we have the staffing capacity only to install software available in the [EasyBuild recipe catalog](https://github.com/easybuilders/easybuild-easyconfigs/tree/develop/easybuild/easyconfigs). We can provide advice and troubleshooting assistance for groups needing to install outside of this environment via help tickets. 
+
+We will be hosting office hours beginning in the next few weeks for anyone with questions about the new environment or how to build software for their groups.  More information will be posted on our communication channels soon.  

--- a/pages/howto/newenv.md
+++ b/pages/howto/newenv.md
@@ -15,8 +15,20 @@ Users new to CCR after August 8, 2023 will automatically be put into the new env
 ## Existing Users - How to Transition 
 
 - Create a file in your home directory named .ccr_new_modules.  Log out & back in again.
-- Ensure that nothing has been added to the `.bashrc` file in your home directory.  Comment out or remove anything not provided by CCR.  This is what your `.bashrc` file should look like:  
+- Ensure that nothing has been added to the `.bashrc` file in your home directory.  Command aliases are usually fine; however, comment out or remove anything else not provided by CCR.  This is what your `.bashrc` file should look like:  
 ```
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+        . /etc/bashrc
+fi
+
+# Uncomment the following line if you don't like systemctl's auto-paging feature:
+# export SYSTEMD_PAGER=
+
+# User specific aliases and functions
+
 ```
 - Follow the directions [below](#the-new-resources) to access the new resources    
 - If you have existing software modules you or your group have built, they will likely need to be re-built for this environment.  See [here](#existing-modules) for more information    
@@ -55,18 +67,19 @@ The newest compute nodes available at CCR in the UB-HPC cluster have been put in
 #SBATCH --partition=general-compute
 #SBATCH --qos=general-compute
 #SBATCH --reservation=ubhpc-future
-#SBATCH --export=NONE
 ```
 
-**Using `srun`?**  If you use `srun` in your job script you need to change the `--export=NONE` option to `--export=NIL` otherwise your environment will not propogate properly to the compute node.  
-
-**using `salloc`?** If you use `salloc` for interactive jobs, you must specify the reservation in your salloc command and run an additional command after being allocated a node:  
+**Using `salloc`?** If you use `salloc` for interactive jobs, you must specify the reservation in your salloc command and run an additional command after being allocated a node:  
 
 ```
 salloc --reservation=ubhpc-future --qos=general-compute --partition=general-compute  --job-name "MyJob" --nodes=1 --ntasks=1 --mem=8G --time=00:30:00  
 
 srun --pty /bin/bash --login
 ```
+
+!!! Tip "Module command errors"  
+    Users submitting jobs to older avx2 architecture-based nodes in the faculty cluster may run into issues with the login node environment persisting into the job environment.  This may present with the error "module command not found."  Please contact [CCR Help](../help.md) for guidance.  The error "module not found" means the module is not available for the architecture of the node you're running on.  CCR's software modules are architecture dependent and many modules have not been built for avx2 nodes as these older nodes are being removed from the UB-HPC cluster. 
+
 
 ## Existing Modules  
 

--- a/pages/howto/ondemand.md
+++ b/pages/howto/ondemand.md
@@ -1,6 +1,6 @@
 # Open OnDemand Features & Customizations  
 
-Version 3.0 of Open OnDemand introduced many new features that CCR users now have access to.  We've also changed how we offer resources and the apps you might be used to.  Here we'll cover those changes, some of the new features, and how you can customize your portal experience. Our primarly OnDemand documentation can be [found here](../portals/ood.md)  
+[Version 3.0 of Open OnDemand](https://ondemand-future.ccr.buffalo.edu) introduced many new features that CCR users now have access to.  We've also changed how we offer resources and the apps you might be used to.  Here we'll cover those changes, some of the new features, and how you can customize your portal experience. Our primarly OnDemand documentation can be [found here](../portals/ood.md)  
 
 !!! Warning "Important Environment Info!"  
     This version of OnDemand uses CCR's new software modules automatically.  You do not have to do anything to utilize these modules.  You will not have access to the old modules in /util. Please refer to the [software module documentation](../software/modules.md) as there are lots of new features available! 

--- a/pages/hpc/jobs.md
+++ b/pages/hpc/jobs.md
@@ -1,5 +1,7 @@
 # Running Jobs
 
+==As of August 2023, users should be using CCR's new environment.  See [here](../howto/newenv.md) for more information on how to transition==  
+
 Our HPC system is shared among many researchers and CCR manages usage of the systems through jobs. Jobs are simply an allotment of resources that can be used to execute processes. CCR uses a program named Slurm, the Simple Linux Utility for Resource Management, to create and manage jobs.
 
 In order to run a program on a cluster, you must request resources from Slurm to generate a job. Resources are requested from a login node. You then provide commands to run your program on those requested resources (compute nodes).

--- a/pages/index.md
+++ b/pages/index.md
@@ -7,6 +7,8 @@ This documentation covers the use of CCR's research computing and research cloud
 !!! Tip   
     CCR provides UB's research computing and research cloud resources. All other IT services and support at UB are provided by [UBIT](https://buffalo.edu/ubit)  
 
+==As of August 2023, new users have access to CCR's new environment.  See [here](howto/newenv.md) for more information==  
+
 ## What do you want to do?
 
 These links provide info on the most popular topics while the left navigation

--- a/pages/portals/ood.md
+++ b/pages/portals/ood.md
@@ -1,5 +1,7 @@
 # OnDemand
 
+==As of August 2023, users should begin using [OnDemand 3.0](https://ondemand-future.ccr.buffalo.edu).  See [here](../howto/ondemand.md) for more information==  
+
 Open OnDemand is a browser based single point of access for all of CCR's clusters, shared storage, and remote visualization servers.  OnDemand provides a graphical interface to view, edit, download, and upload files, manage and create job templates for CCR's clusters, and access interactive applications such as remote desktops to cluster nodes and the visualization servers, as well as GUI-based software like Matlab, Jupyter Notebooks, RStudio Desktop, and vscode.  All of this is done through the browser on almost any device, requires no additional software to be installed, and with minimal knowledge of Linux and job scheduler commands.  
 
 _**This product is an open source project developed by [Ohio Supercomputer Center](https://openondemand.org).**_
@@ -13,9 +15,10 @@ _**This product is an open source project developed by [Ohio Supercomputer Cente
     (either on campus or connected to their VPN services). [See here](../getting-access.md#vpn-access)
 
 Login to [OnDemand](https://ondemand.ccr.buffalo.edu) with your CCR account.  Don't have one yet? [See here](../getting-access.md)  
+New users should use [OnDemand 3.0](https://ondemand-future.ccr.buffalo.edu)   
 
 !!! Tip "First Login - Additional Steps"
-    On first login your home directory will need to be created.  Follow the instructions provided after login to create your home directory and run the script to generate a SSH key pair for use on the cluster and within the OnDemand terminal app.  If, after completing the steps, the OnDemand dashboard does not reload, log out and back in again.  
+    On first login your home directory will need to be created.  Follow the instructions provided after login to initiate the creation of your home directory, SSH key pair for use on the cluster, and setup the new software modules within the OnDemand terminal app.  If, after completing the steps, the OnDemand dashboard does not reload, log out and back in again.  
 
 ## OnDemand Features  
 

--- a/pages/software/modules.md
+++ b/pages/software/modules.md
@@ -1,5 +1,7 @@
 # Available Software
 
+==All users have access to CCR's new environment of software and compute nodes.  See [here](../howto/newenv.md) for more information==  
+
 CCR maintains a suite of software programs, libraries, and toolchains commonly
 used in scientific computing. The HPC clusters can execute most software that
 runs under Linux. In many cases, the software you need will already be
@@ -7,9 +9,8 @@ installed and available to you on the compute nodes. You access the software
 using what's called a "module".  If the software you need is not available, you
 [can ask our staff](building.md#software-build-requests) to install it for you or [do it yourself](building.md).
 
-!!! Warning "New software infrastructure now available"
-    CCR has moved to a new software infrastructure described in this document.
-    As of the Summer of 2023 existing users will be required to migrate to the new modules. To start using the new software now, simply run this command `touch ~/.ccr_new_modules`.  You will need to logout and log back in for the changes to take effect. As of April 2023, new users will be automatically setup in this environment and can skip this step.  If you'd like to temporarily go back to using the old modules in `/util`, simply remove that file `rm ~/.ccr_new_modules`.
+!!! Warning "Software Module Transition Required"
+    Existing users can migrate to the new modules simply by running this command:  `touch ~/.ccr_new_modules`.  You will need to logout and log back in for the changes to take effect. As of August 2023, new users will automatically be setup in this environment and can skip this step.  If you'd like to temporarily go back to using the old modules in `/util`, simply remove that file `rm ~/.ccr_new_modules`.  However, the old modules will be decommissioned this fall.  See [here](../howto/newenv.md) for more information.
 
 ## Using Modules
 


### PR DESCRIPTION
one pager on CCR's new environment and how users should migrate.  added highlighted links at top of other pages to point to this in the event users find those pages first